### PR TITLE
Fixed #4 prototype problem

### DIFF
--- a/canvas-toBlob.js
+++ b/canvas-toBlob.js
@@ -18,7 +18,7 @@
 var
 	  Uint8Array = view.Uint8Array
 	, HTMLCanvasElement = view.HTMLCanvasElement
-	, canvas_proto = HTMLCanvasElement || HTMLCanvasElement.prototype
+	, canvas_proto = HTMLCanvasElement.prototype || HTMLCanvasElement
 	, is_base64_regex = /\s*;\s*base64\s*(?:;|$)/i
 	, to_data_url = "toDataURL"
 	, base64_ranks


### PR DESCRIPTION
There was an assumption that the canvas_proto variable is holding a reference to the actual prototype. 
I left the `|| HTMLCanvasElement` part in case it was actually there for some odd browser. Consider removing that too
