### PR TITLE
Add IE10+ msToBlob support (fix #10)

### DIFF
--- a/canvas-toBlob.js
+++ b/canvas-toBlob.js
@@ -77,7 +77,11 @@ if (HTMLCanvasElement && !canvas_proto.toBlob) {
 		} if (this.mozGetAsFile) {
 			callback(this.mozGetAsFile("canvas", type));
 			return;
+		} if (this.msToBlob && type === "image/png") {
+			callback(this.msToBlob());
+			return;
 		}
+
 		var
 			  args = Array.prototype.slice.call(arguments, 1)
 			, dataURI = this[to_data_url].apply(this, args)


### PR DESCRIPTION
I tried to follow the existing coding style wrt the mozGetAsFile block, but please let me know if I got it wrong. This is for issue #10.
